### PR TITLE
Fix issue #16 using "auto" color

### DIFF
--- a/RtfPipe.Tests/GitHubIssues.Issue16b.approved.html
+++ b/RtfPipe.Tests/GitHubIssues.Issue16b.approved.html
@@ -1,0 +1,23 @@
+﻿<div style="font-size:12pt;font-family:Courier;">
+    <p style="margin:0;">This line is font 0 which is courier and use default color (no color tag will be added)
+        <br />
+        <span style="font-family:ProFontWindows;">This line is font 1
+            <br />
+        </span>This line is font 0 again
+        <br />This line has a 
+        <span style="color:#FF0000;">red 
+        </span>word
+        <br />
+        <mark style="background:#FF00FF;">while this line has a 
+        </mark>
+        <mark style="background:#FF00FF;color:#FFFFFF;">white 
+        </mark>
+        <mark style="background:#FF00FF;">word and is highlighted in magenta
+            <br />
+        </mark>Finally, back to the default color. Color 0 is "auto" and it is transformed as "no color" on html.
+    </p>
+    <p style="border-top:1px solid #FF0000;margin:0;">This paragraph has a red border top.
+    </p>
+    <p style="border-top:1px solid;margin:0;">This paragraph has a border top with default color.
+    </p>
+ </div>

--- a/RtfPipe.Tests/GitHubIssues.cs
+++ b/RtfPipe.Tests/GitHubIssues.cs
@@ -42,6 +42,27 @@ Finally, back to the default color.\line
     }
 
     [TestMethod]
+    public void Issue16b()
+    {
+      this.VerifyCurrentLegacyScenario(@"{\rtf1\ansi\deff0 {\fonttbl {\f0 Courier;}{\f1 ProFontWindows;}}
+{\colortbl;\red0\green0\blue0;\red255\green255\blue255;\red255\green0\blue255;\red255\green0\blue0;}
+\pard\chcbpat0\cb0\cbpat0
+This line is font 0 which is courier and use default color (no color tag will be added)\line
+\f1
+This line is font 1\line
+\f0
+This line is font 0 again\line
+This line has a \cf4 red \cf1 word\line
+\highlight3 while this line has a \cf2 white \cf1 word and is highlighted in magenta\line
+\highlight0\cb0\cf0 Finally, back to the default color. Color 0 is ""auto"" and it is transformed as ""no color"" on html.\par
+\pard\brdrt\brdrs\brdrw15\brdrcf4
+This paragraph has a red border top.\par
+\pard\brdrt\brdrs\brdrw15\brdrcf0
+This paragraph has a border top with default color.\par
+}");
+    }
+
+    [TestMethod]
     public void Issue17()
     {
       const string rtf = @"{\rtf1\ansi\ansicpg1252\uc1\deff1{

--- a/RtfPipe/Html/CssString.cs
+++ b/RtfPipe/Html/CssString.cs
@@ -36,15 +36,27 @@ namespace RtfPipe.Model
         else if (token is FontSize fontSize)
           Append("font-size", fontSize.Value.ToPt().ToString("0.#", CultureInfo.InvariantCulture) + "pt");
         else if (token is BackgroundColor background)
-          Append("background", "#" + background.Value);
+        {
+          if (!background.Value.IsAuto)
+            Append("background", "#" + background.Value);
+        }
         else if (token is ParagraphBackgroundColor backgroundPara)
-          Append("background", "#" + backgroundPara.Value);
+        {
+          if (!backgroundPara.Value.IsAuto)
+            Append("background", "#" + backgroundPara.Value);
+        }
         else if (token is CellBackgroundColor backgroundCell)
-          Append("background", "#" + backgroundCell.Value);
+        {
+          if (!backgroundCell.Value.IsAuto)
+            Append("background", "#" + backgroundCell.Value);
+        }
         else if (token is IsAllCaps capitalToken)
           Append("text-transform", capitalToken.Value ? "uppercase" : "none");
         else if (token is ForegroundColor color)
-          Append("color", "#" + color.Value);
+        {
+          if (!color.Value.IsAuto)
+            Append("color", "#" + color.Value);
+        }
         else if (token is TextAlign align)
           Append("text-align", align.Value.ToString().ToLowerInvariant());
         else if (token is SpaceAfter spaceAfter)
@@ -94,7 +106,10 @@ namespace RtfPipe.Model
         else if (token is IsDoubleStrike || token is UnderlineDouble)
           Append("text-decoration-style", "double");
         else if (token is UnderlineColor underlineColor)
-          Append("text-decoration-color", "#" + underlineColor.Value);
+        {
+          if (!underlineColor.Value.IsAuto)
+            Append("text-decoration-color", "#" + underlineColor.Value);
+        }
         else if (token is UnderlineWord)
           Append("text-decoration-skip", "spaces");
         else if (token is PositionOffset offset)
@@ -435,7 +450,7 @@ namespace RtfPipe.Model
             break;
         }
 
-        if (border.Color != null)
+        if (border.Color != null && !border.Color.IsAuto)
           _builder.Append(" #").Append(border.Color);
       }
 

--- a/RtfPipe/Html/HtmlTag.cs
+++ b/RtfPipe/Html/HtmlTag.cs
@@ -100,8 +100,8 @@ namespace RtfPipe.Model
     {
       Styles =
       {
-        new BackgroundColor(new ColorValue(255, 255, 0)),
-        new ForegroundColor(new ColorValue(0, 0, 0))
+        new BackgroundColor(ColorValue.Yellow),
+        new ForegroundColor(ColorValue.Black)
       }
     };
     public static HtmlTag Meta { get; } = new HtmlTag("meta");

--- a/RtfPipe/Html/HtmlVisitor.cs
+++ b/RtfPipe/Html/HtmlVisitor.cs
@@ -15,8 +15,8 @@ namespace RtfPipe.Model
     private Stack<StyleList> _stack = new Stack<StyleList>();
     private IEnumerable<IToken> _stylesheet = new IToken[]
     {
-      new ForegroundColor(new ColorValue(0, 0, 0)),
-      new BackgroundColor(new ColorValue(255, 255, 255))
+      new ForegroundColor(ColorValue.Black),
+      new BackgroundColor(ColorValue.White)
     };
     private readonly XmlWriter _writer;
 
@@ -450,15 +450,18 @@ namespace RtfPipe.Model
       }
       if (styleList.TryRemoveFirst(out BackgroundColor highlight))
       {
-        _writer.WriteStartElement("mark");
-        styleList.RemoveWhere(s => s is ForegroundColor);
-        var markCss = new CssString(GetNewStyles(run.Styles.Where(s => s is BackgroundColor || s is ForegroundColor), HtmlTag.Mark), ElementType.Span, run.Styles);
-        if (markCss.Length > 0)
+        if (!highlight.Value.IsAuto)
         {
-          _writer.WriteAttributeString("style", markCss.ToString());
-          stylesWritten = true;
+          _writer.WriteStartElement("mark");
+          styleList.RemoveWhere(s => s is ForegroundColor);
+          var markCss = new CssString(GetNewStyles(run.Styles.Where(s => s is BackgroundColor || s is ForegroundColor), HtmlTag.Mark), ElementType.Span, run.Styles);
+          if (markCss.Length > 0)
+          {
+            _writer.WriteAttributeString("style", markCss.ToString());
+            stylesWritten = true;
+          }
+          endTags++;
         }
-        endTags++;
       }
 
       var css = new CssString(styleList, elementType, run.Styles);

--- a/RtfPipe/Model/Builder.cs
+++ b/RtfPipe/Model/Builder.cs
@@ -18,9 +18,11 @@ namespace RtfPipe.Model
       var result = new RtfHtml();
 
       if (document.ColorTable.Any())
-        defaultStyles.Add(new ForegroundColor(document.ColorTable.First()));
-      else
-        defaultStyles.Add(new ForegroundColor(new ColorValue(0, 0, 0)));
+      {
+        var color = document.ColorTable.First();
+        if (!color.IsAuto)
+          defaultStyles.Add(new ForegroundColor(color));
+      }
 
       foreach (var token in document.Contents)
       {

--- a/RtfPipe/Model/RawBuilder.cs
+++ b/RtfPipe/Model/RawBuilder.cs
@@ -16,10 +16,13 @@ namespace RtfPipe.Model
       {
         new FontSize(UnitValue.FromHalfPoint(24))
       };
+
       if (document.ColorTable.Any())
-        defaultStyles.Add(new ForegroundColor(document.ColorTable.First()));
-      else
-        defaultStyles.Add(new ForegroundColor(new ColorValue(0, 0, 0)));
+      {
+        var color = document.ColorTable.First();
+        if (!color.IsAuto)
+          defaultStyles.Add(new ForegroundColor(color));
+      }
 
       foreach (var token in document.Contents)
       {

--- a/RtfPipe/Parser.Mapping.cs
+++ b/RtfPipe/Parser.Mapping.cs
@@ -10,6 +10,8 @@ namespace RtfPipe
 
     private IToken GetControlWord(string name, int number = int.MinValue)
     {
+      ColorValue color;
+
       switch (name)
       {
         // Characters
@@ -393,16 +395,16 @@ namespace RtfPipe
         case "caps":
           return new IsAllCaps(number != 0);
         case "cbpat":
-          return new ParagraphBackgroundColor(ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new ParagraphBackgroundColor(color) : null;
         case "cb":
         case "chcbpat":
         case "highlight":
-          return new BackgroundColor(number == 0 ? new ColorValue(255, 255, 255) : ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new BackgroundColor(color) : null;
         case "shading":
           var shade = (byte)(255 - Math.Min(Math.Max(0, number * 255 / 10000), 255));
           return new ParagraphBackgroundColor(new ColorValue(shade, shade, shade));
         case "cf":
-          return new ForegroundColor(ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new ForegroundColor(color) : null;
         case "dn":
           if (number > 0)
             return new PositionOffset(UnitValue.FromHalfPoint(number));
@@ -434,7 +436,7 @@ namespace RtfPipe
         case "ul":
           return new IsUnderline(number != 0);
         case "ulc":
-          return new UnderlineColor(ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new UnderlineColor(color) : null;
         case "uld":
           return new UnderlineDotted();
         case "uldash":
@@ -616,7 +618,7 @@ namespace RtfPipe
         case "clvertalb":
           return new CellVerticalAlign(VerticalAlignment.Bottom);
         case "clcbpat":
-          return new CellBackgroundColor(ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new CellBackgroundColor(color) : null;
         case "nesttableprops":
           return new NestedTableProperties();
         case "nonesttables":
@@ -665,7 +667,7 @@ namespace RtfPipe
         case "brdrw":
           return new BorderWidth(new UnitValue(number, UnitType.Twip));
         case "brdrcf":
-          return new BorderColor(ColorByIndex(number));
+          return ColorByIndex(number, out color) ? new BorderColor(color) : null;
         case "brdrt":
           return new ParagraphBorderSide(BorderPosition.Top);
         case "brdrr":
@@ -729,13 +731,22 @@ namespace RtfPipe
           return new GenericWord(name, number);
       }
     }
-    
+
     static HashSet<string> known = new HashSet<string>();
-    private ColorValue ColorByIndex(int number)
+    /// <summary>
+    /// Find the color on the document color table by its index/positon.
+    /// </summary>
+    /// <param name="number">Position of the color.</param>
+    /// <param name="color">Color on the document color table.</param>
+    /// <returns>True if it is a custom defined color. False if it is defined as auto or default color.</returns>
+    private bool ColorByIndex(int number, out ColorValue color)
     {
       if (number >= 0 && number < _document.ColorTable.Count)
-        return _document.ColorTable[number];
-      return new ColorValue(0, 0, 0);
+        color = _document.ColorTable[number];
+      else
+        color = ColorValue.Auto; // If not found, returns auto color.
+
+      return !color.IsAuto;
     }
   }
 }

--- a/RtfPipe/Parser.cs
+++ b/RtfPipe/Parser.cs
@@ -406,7 +406,7 @@ namespace RtfPipe
           }
           else
           {
-            _document.ColorTable.Add(new ColorValue(0, 0, 0));
+            _document.ColorTable.Add(ColorValue.Auto); // Empty color (auto)
           }
 
           _context.Peek().TokenBuffer.Clear();

--- a/RtfPipe/Style/ColorValue.cs
+++ b/RtfPipe/Style/ColorValue.cs
@@ -8,6 +8,16 @@ namespace RtfPipe
   {
     public static readonly ColorValue Black = new ColorValue(0, 0, 0);
     public static readonly ColorValue White = new ColorValue(255, 255, 255);
+    public static readonly ColorValue Yellow = new ColorValue(255, 255, 0);
+    /// <summary>
+    /// Auto or default color. On HTML this is rendered as no color specified (no color tag will be added).
+    /// </summary>
+    public static readonly ColorValue Auto = new ColorValue();
+
+    public ColorValue() : this(0, 0, 0)
+    {
+      this.IsAuto = true;
+    }
 
     public ColorValue(byte red, byte green, byte blue)
     {
@@ -16,6 +26,11 @@ namespace RtfPipe
       this.Blue = blue;
     }
 
+    /// <summary>
+    /// True indicates that is Auto or Default color because it is defined as empty on Color's table.
+    /// On HTML this is rendered as no color specified (no color tag will be added).
+    /// </summary>
+    public bool IsAuto { get; } = false;
     public byte Red { get; }
     public byte Green { get; }
     public byte Blue { get; }
@@ -29,7 +44,8 @@ namespace RtfPipe
 
     public bool Equals(ColorValue other)
     {
-      return Red == other.Red
+      return IsAuto == other.IsAuto
+        && Red == other.Red
         && Green == other.Green
         && Blue == other.Blue;
     }
@@ -44,17 +60,18 @@ namespace RtfPipe
       int hash = Red;
       hash = HashTool.AddHashCode(hash, Green);
       hash = HashTool.AddHashCode(hash, Blue);
+      hash = HashTool.AddHashCode(hash, IsAuto);
       return hash;
     }
 
     public override string ToString()
     {
-      return $"{Red:X2}{Green:X2}{Blue:X2}";
+      return IsAuto ? string.Empty : $"{Red:X2}{Green:X2}{Blue:X2}";
     }
 
     public ColorValue Clone()
     {
-      return new ColorValue(Red, Green, Blue);
+      return IsAuto ? ColorValue.Auto : new ColorValue(Red, Green, Blue);
     }
 
     public static bool operator ==(ColorValue x, ColorValue y)


### PR DESCRIPTION
## Fix: Handle RTF "auto" color correctly in HTML output

### Problem
- When RTF documents use the "auto" color (empty entry at index 0 in color table), the library incorrectly outputs `color:#000000` in HTML instead of omitting the color style to allow inheritance.
- Tag \highlight0 reported as issue #16 was working because of a specific "if" added just for this test case.

### Solution
- Modified ColorValue class to add an "auto" color.
- Updated color parsing processing to treat "auto" color as "no color" rather than black.
- Added test case `Issue16b` to verify the fix.